### PR TITLE
auto add "magnet:?xt=urn:btih:" prefix for "BitTorrent info hash"

### DIFF
--- a/src/scripts/services/ariaNgCommonService.js
+++ b/src/scripts/services/ariaNgCommonService.js
@@ -73,6 +73,8 @@
                         result.push(line);
                     } else if (line.match(/^magnet:\?.+$/)) {
                         result.push(line);
+                    } else if (/^[a-f0-9]{40}$/i.test(line)) {
+                      result.push('magnet:?xt=urn:btih:' + line);
                     }
                 }
 


### PR DESCRIPTION
为磁力HASH值自动添加前缀  :P

举例:
在新建任务时直接粘贴 `A2E0412C2D8AA3BE91E1D32FEAE59188BDCE6457` 即可添加对应的 `magnet` 的任务.