### PR TITLE
[fix] resolve New button not working in localhost

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -70,7 +70,7 @@
             <div class="navbar-toolbar">
                 <ul class="nav navbar-nav">
                     <li>
-                        <a class="toolbar" title="{{'New' | translate}}" ng-href="#!/new">
+                        <a class="toolbar" title="{{'New' | translate}}" href="#!/new">
                             <i class="fa fa-plus"></i>
                             <span translate>New</span>
                         </a>

--- a/src/scripts/config/configuration.js
+++ b/src/scripts/config/configuration.js
@@ -1,7 +1,9 @@
 (function () {
     'use strict';
 
-    angular.module('ariaNg').config(['$qProvider', '$translateProvider', 'localStorageServiceProvider', 'NotificationProvider', 'ariaNgConstants', 'ariaNgLanguages', function ($qProvider, $translateProvider, localStorageServiceProvider, NotificationProvider, ariaNgConstants, ariaNgLanguages) {
+    angular.module('ariaNg').config(['$compileProvider', '$qProvider', '$translateProvider', 'localStorageServiceProvider', 'NotificationProvider', 'ariaNgConstants', 'ariaNgLanguages', function ($compileProvider, $qProvider, $translateProvider, localStorageServiceProvider, NotificationProvider, ariaNgConstants, ariaNgLanguages) {
+        $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|chrome-extension):/);
+        
         $qProvider.errorOnUnhandledRejections(false);
 
         localStorageServiceProvider


### PR DESCRIPTION
@mayswind I fixed the issues referred below.

This issue is caused by Angular prefixing a non-whitelisted URL with `unsafe:` when using a protocol such as `chrome-extension:`, as only `http`, `https`, `ftp` and `mailto` are enabled by default. 

Adding URL protocols to Angular's whitelist using a regular expression resolves this problem.

Feel free to merge it as I think this additional touch allows more users to enjoy your nice work. Thanks.

**Issue Referred:**
https://github.com/mayswind/AriaNg/issues/187
https://github.com/mayswind/AriaNg/issues/73