### PR TITLE
Add bt-seed-unverified control to tasks options panel

### DIFF
--- a/src/scripts/config/aria2Options.js
+++ b/src/scripts/config/aria2Options.js
@@ -1013,6 +1013,11 @@
                 canUpdate: 'new|waiting|paused'
             },
             {
+                key: 'bt-seed-unverified',
+                category: 'bittorrent',
+                canShow: 'new|active|waiting|paused'
+            },
+            {
                 key: 'conditional-get',
                 category: 'global',
                 canShow: 'new'


### PR DESCRIPTION
Add `bt-seed-unverified` option task by task.

This option is needed for fine grained control on torrent seeding tasks, its behavior is dependent on the status of option `check-integrity` (or `-V` on the command line) and the presence of an `.aria2` control file.

The default `check-integrity=false` and `bt-seed-unverified=false` tries to overwrite any existing file if present and does not permit to seed a existing file without aria2 control file. (you need to use an external command to check hash and create the aria2 control file : `aria2c --force-save --check-integrity --hash-check-only`)

Setting `bt-seed-unverified=true` and leaving default `check-integrity=false` allows to seed a torrent without checking hash of existing files. (It can seed partial or damaged files and you can't trigger a deferred integrity check without the `check-integrity` option)

Setting global `check-integrity=true` and leaving default `bt-seed-unverified=false` check every torrent hash before starting a task. (It can lead to very long aria2 start time if current session contains a lot of torrent tasks)

The common use case for me is to start aria2 daemon with `check-integrity=true` and `bt-seed-unverified=true` allowing for quicker start time that will read the status of existing torrent tasks in aria2 control file, then being able to add seeding task with integrity check by switching the `bt-seed-unverified` option to `false` when adding an existing torrent or magnet.

With global option `check-integrity=true` the `bt-seed-unverified` value can also be switched on active tasks and trigger an immediate integrity check, then can be switched back to its previous value to prevent triggering a long hash check on aria2 startup.


I checked in previous issues (#388) that you didn't want to add `check-integrity` to task's options because it's an uncommon use case, I don't think this new `bt-seed-unverified` option will clutter the task details panel and it's specific to Bittorrent task which has its own display category, with or without the `check-integrity` switch it allows to start a torrent in seed mode without any CLI manipulation so I think it's a good option to offer for advanced users.