### PR TITLE
Ability to remove tasks without confirmation

### DIFF
--- a/src/scripts/config/constants.js
+++ b/src/scripts/config/constants.js
@@ -39,6 +39,7 @@
         rpcListDisplayOrder: 'recentlyUsed',
         afterCreatingNewTask: 'task-list',
         removeOldTaskAfterRetrying: false,
+        confirmTaskRemoval: true,
         afterRetryingTask: 'task-list-downloading',
         displayOrder: 'default:asc',
         fileListDisplayOrder: 'default:asc',

--- a/src/scripts/config/defaultLanguage.js
+++ b/src/scripts/config/defaultLanguage.js
@@ -182,6 +182,7 @@
             'Navigate to Downloading Tasks Page': 'Navigate to Downloading Tasks Page',
             'Stay on Current Page': 'Stay on Current Page',
             'Remove Old Tasks After Retrying': 'Remove Old Tasks After Retrying',
+            'Confirm Task Removal': 'Confirm Task Removal',
             'RPC List Display Order': 'RPC List Display Order',
             'Recently Used': 'Recently Used',
             'RPC Alias': 'RPC Alias',

--- a/src/scripts/controllers/main.js
+++ b/src/scripts/controllers/main.js
@@ -290,7 +290,7 @@
                 return;
             }
 
-            ariaNgLocalizationService.confirm('Confirm Remove', 'Are you sure you want to remove the selected task?', 'warning', function () {
+            var removeTasks = function () {
                 $rootScope.loadPromise = aria2TaskService.removeTasks(tasks, function (response) {
                     if (response.hasError && tasks.length > 1) {
                         ariaNgLocalizationService.showError('Failed to remove some task(s).');
@@ -310,7 +310,13 @@
                         }
                     }
                 }, (tasks.length > 1));
-            });
+            };
+
+            if (ariaNgSettingService.getConfirmTaskRemoval()) {
+                ariaNgLocalizationService.confirm('Confirm Remove', 'Are you sure you want to remove the selected task?', 'warning', removeTasks);
+            } else {
+                removeTasks();
+            };
         };
 
         $scope.clearStoppedTasks = function () {

--- a/src/scripts/controllers/settings-ariang.js
+++ b/src/scripts/controllers/settings-ariang.js
@@ -187,6 +187,10 @@
             ariaNgSettingService.setRemoveOldTaskAfterRetrying(value);
         };
 
+        $scope.setConfirmTaskRemoval = function (value) {
+            ariaNgSettingService.setConfirmTaskRemoval(value);
+        };
+
         $scope.setAfterRetryingTask = function (value) {
             ariaNgSettingService.setAfterRetryingTask(value);
         };

--- a/src/scripts/services/ariaNgSettingService.js
+++ b/src/scripts/services/ariaNgSettingService.js
@@ -381,6 +381,12 @@
             setRemoveOldTaskAfterRetrying: function (value) {
                 setOption('removeOldTaskAfterRetrying', value);
             },
+            getConfirmTaskRemoval: function () {
+                return getOption('confirmTaskRemoval');
+            },
+            setConfirmTaskRemoval: function (value) {
+                setOption('confirmTaskRemoval', value);
+            },
             getAfterRetryingTask: function () {
                 return getOption('afterRetryingTask');
             },

--- a/src/views/settings-ariang.html
+++ b/src/views/settings-ariang.html
@@ -173,6 +173,17 @@
                     </div>
                     <div class="row">
                         <div class="setting-key setting-key-without-desc col-sm-4">
+                            <span translate>Confirm Task Removal</span>
+                        </div>
+                        <div class="setting-value col-sm-8">
+                            <select class="form-control" style="width: 100%;" ng-model="context.settings.confirmTaskRemoval"
+                                    ng-change="setConfirmTaskRemoval(context.settings.confirmTaskRemoval)"
+                                    ng-options="option.value as (option.name | translate) for option in context.trueFalseOptions">
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="setting-key setting-key-without-desc col-sm-4">
                             <span translate>Import / Export AriaNg Settings</span>
                         </div>
                         <div class="setting-value col-sm-8">


### PR DESCRIPTION
Motivation: delete button shows dropdown with 'Remove Task' option, therefore it's not so easy to remove task accidentally.
Note: only 'default language' translation is added for the setting, cause I don't know Chinese. 👲