### PR TITLE
Fix

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -346,7 +346,6 @@
 <!-- endbuild -->
 <!-- build:js js/aria-ng.min.js -->
 <script src="scripts/core/__core.js"></script>
-<script src="scripts/core/__fix.js"></script>
 <script src="scripts/core/app.js"></script>
 <script src="scripts/core/router.js"></script>
 <script src="scripts/core/root.js"></script>

--- a/src/styles/core/core.css
+++ b/src/styles/core/core.css
@@ -94,6 +94,7 @@ td {
 
 .content-wrapper > .content-body {
     overflow-y: scroll;
+    min-height: calc(100vh - 95px);
 }
 
 .main-footer > .navbar {

--- a/src/views/new.html
+++ b/src/views/new.html
@@ -84,7 +84,7 @@
                                 </div>
                             </div>
                         </div>
-                        <ng-setting ng-repeat="option in context.availableOptions" ng-if="context.optionFilter[option.category]"
+                        <ng-setting ng-repeat="option in context.availableOptions" ng-if="context.globalOptions && context.optionFilter[option.category]"
                                     option="option" lazy-save-timeout="0" default-value="context.globalOptions[option.key]"
                                     on-change-value="setOption(key, value, optionStatus)"></ng-setting>
                     </div>


### PR DESCRIPTION
force to show default options, without context.globalOptions all options are blank

before 
![Image](https://i.imgur.com/f21XNFQ.jpg)
after
![Image](https://i.imgur.com/KkafMa5.jpg)