### PR TITLE
fix options

### DIFF
--- a/src/views/new.html
+++ b/src/views/new.html
@@ -84,7 +84,8 @@
                                 </div>
                             </div>
                         </div>
-                        <ng-setting ng-repeat="option in context.availableOptions" ng-if="context.optionFilter[option.category]"
+                        <ng-setting ng-repeat="option in context.availableOptions"
+                                    ng-if="context.globalOptions && context.optionFilter[option.category]"
                                     option="option" lazy-save-timeout="0" default-value="context.globalOptions[option.key]"
                                     on-change-value="setOption(key, value, optionStatus)"></ng-setting>
                     </div>


### PR DESCRIPTION
Force to show default options, without context.globalOptions all options are blank

before, you need switch 2 times options to show <-- thats bug.
![Image](https://i.imgur.com/f21XNFQ.jpg)
after fix, first time show all defaults.
![Image](https://i.imgur.com/KkafMa5.jpg)