### PR TITLE
修复在 Cordova 中无法选择种子文件的问题

### DIFF
--- a/src/scripts/controllers/new.js
+++ b/src/scripts/controllers/new.js
@@ -130,7 +130,7 @@
         $scope.openTorrent = function () {
             ariaNgFileService.openFileContent({
                 scope: $scope,
-                fileFilter: 'application/x-bittorrent',
+                fileFilter: 'application/x-bittorrent,.torrent',
                 fileType: 'binary'
             }, function (result) {
                 $scope.context.uploadFile = result;
@@ -144,7 +144,7 @@
         $scope.openMetalink = function () {
             ariaNgFileService.openFileContent({
                 scope: $scope,
-                fileFilter: '.meta4,.metalink',
+                fileFilter: 'application/octet-stream,application/metalink4+xml,application/metalink+xml,.meta4,.metalink',  // weird
                 fileType: 'binary'
             }, function (result) {
                 $scope.context.uploadFile = result;

--- a/src/scripts/controllers/new.js
+++ b/src/scripts/controllers/new.js
@@ -130,7 +130,7 @@
         $scope.openTorrent = function () {
             ariaNgFileService.openFileContent({
                 scope: $scope,
-                fileFilter: '.torrent',
+                fileFilter: 'application/x-bittorrent',
                 fileType: 'binary'
             }, function (result) {
                 $scope.context.uploadFile = result;

--- a/src/scripts/controllers/new.js
+++ b/src/scripts/controllers/new.js
@@ -144,7 +144,7 @@
         $scope.openMetalink = function () {
             ariaNgFileService.openFileContent({
                 scope: $scope,
-                fileFilter: 'application/octet-stream,application/metalink4+xml,application/metalink+xml,.meta4,.metalink',  // weird
+                fileFilter: 'application/metalink4+xml,application/metalink+xml,.meta4,.metalink',
                 fileType: 'binary'
             }, function (result) {
                 $scope.context.uploadFile = result;

--- a/src/scripts/controllers/settings-ariang.js
+++ b/src/scripts/controllers/settings-ariang.js
@@ -203,7 +203,7 @@
         $scope.openAriaNgConfigFile = function () {
             ariaNgFileService.openFileContent({
                 scope: $scope,
-                fileFilter: '.json',
+                fileFilter: 'application/json',
                 fileType: 'text'
             }, function (result) {
                 $scope.context.importSettings = result.content;


### PR DESCRIPTION
在 Cordova （不清楚是否是在所有 Android Webview）中，`<input>` 标签的 `accept` 属性只支持使用合法的 MIME 类型，而不支持使用文件扩展名

`.torrent` 文件的 MIME 类型为 `application/x-bittorrent`

Xmader/aria-ng-gui-android#6