### PR TITLE
add a aria2c command-line-like downloading feature

### DIFF
--- a/src/scripts/controllers/new.js
+++ b/src/scripts/controllers/new.js
@@ -19,14 +19,12 @@
             var tasks = [];
 
             for (var i = 0; i < urls.length; i++) {
-                if (urls[i] === '' || urls[i].trim() === '') {
+                var url = urls[i].trim();
+                if (url === '') {
                     continue;
                 }
 
-                tasks.push({
-                    urls: [urls[i].trim()],
-                    options: options
-                });
+                tasks.push(ariaNgCommonService.parseUrlOptions(url, options));
             }
 
             saveDownloadPath(options);


### PR DESCRIPTION
With this new feature, you can paste a aria2c command-line-like URL into new download input box to download.

For example:

`
aria2c "https://d.pcs.panzi.com/file/619397a2a87c191e5fc247861a511aa2?fid=236717976-250528-76819692508978&rt=pr&sign=FDtAER-DCb740ccc5511e5e8fedcff06b081203-qhGb0Ht???????????????????????????bd=0&chkv=0&dp-logid=2753750731633131255&dp-callid=0&dstime=1618285310&r=305639462&origin_appid=&file_type=0" --out "玩ju总动员.4(2019)英语字幕【更多微：englishclub】.mp4" --header "User-Agent: pan.baidu.com" --header "Cookie: BDUSS=J-RUtGbmxrSGNWTFJHU09?????????????????????????????????????AAAAAAAAAAAAAAAAABOC6V8TgulfeV"
`

![image](https://user-images.githubusercontent.com/1817716/114539892-84f37d80-9c87-11eb-82a1-3f4c86be6f3c.png)

so, you can paste a command-line-like text from some 3rd-party plugin to download for convenient.


