### PR TITLE
Add check-integrity to task settings tab

### DIFF
--- a/src/scripts/config/aria2Options.js
+++ b/src/scripts/config/aria2Options.js
@@ -1031,6 +1031,10 @@
                 canShow: 'new'
             },
             {
+                key: 'check-integrity',
+                category: 'global'
+            },
+            {
                 key: 'file-allocation',
                 category: 'global',
                 canShow: 'new'


### PR DESCRIPTION
Being able to adjust this setting on per-task basis allows to create a task for existing partially downloaded torrent or force verification on a seeding torrent file. Also, it looks like aria2 handles change to this setting nicely in any state so there is no apparent need to limit changeability to certain task states.