### PR TITLE
add pause-metadata option when creating a new bt task

### DIFF
--- a/src/scripts/config/aria2Options.js
+++ b/src/scripts/config/aria2Options.js
@@ -1031,6 +1031,11 @@
                 canUpdate: 'new|waiting|paused'
             },
             {
+                key: 'pause-metadata',
+                category: 'bittorrent',
+                canUpdate: 'new'
+            },
+            {
                 key: 'conditional-get',
                 category: 'global',
                 canShow: 'new'


### PR DESCRIPTION
When creating a bt task, it's possible user wants to select the files of the torrent to download. Instead of downloading and pausing to select the files, `pause-metadata` allows the user to make the selection on the paused task and start it.