### PR TITLE
Improve progress bar UX for 0-byte completed files

### DIFF
--- a/src/scripts/services/aria2TaskService.js
+++ b/src/scripts/services/aria2TaskService.js
@@ -295,7 +295,7 @@
 
             task.totalLength = parseInt(task.totalLength);
             task.completedLength = parseInt(task.completedLength);
-            task.completePercent = (task.totalLength > 0 ? task.completedLength / task.totalLength * 100 : 0);
+            task.completePercent = (task.totalLength > 0 ? task.completedLength / task.totalLength * 100 : (task.status === 'complete' ? 100 : 0));
             task.remainLength = task.totalLength - task.completedLength;
             task.remainPercent = 100 - task.completePercent;
             task.uploadLength = (task.uploadLength ? parseInt(task.uploadLength) : 0);
@@ -336,7 +336,7 @@
                     file.length = parseInt(file.length);
                     file.selected = (file.selected === true || file.selected === 'true');
                     file.completedLength = parseInt(file.completedLength);
-                    file.completePercent = (file.length > 0 ? file.completedLength / file.length * 100 : 0);
+                    file.completePercent = (file.length > 0 ? file.completedLength / file.length * 100 : (task.status === 'complete' ? 100 : 0));
 
                     if (addVirtualFileNode) {
                         file.relativePath = getRelativePath(task, file);


### PR DESCRIPTION
Currently, when a file has a size of 0 bytes (empty file), the progress bar displays `0.00%` even if the task status is `complete`. This can be confusing to users, as it implies the download failed or hasn't started.

This PR introduces the following behaviour for tasks:
- If `totalLength` is 0 and status is `complete` -> `100.00%`
- If `totalLength` is 0 and status is `active` / `waiting` / ... -> `0.00%`

For 0-byte files under (potentially non-0-byte) tasks, the progress is `100.00%` if and only if its parent task is `complete`.

As a side-effect, users can now quickly identify failed downloads via sorting the "Finished / Stopped" menu by "Progress" descendingly. Previously, sorting by "Progress" will mix failed downloads and 0 byte files together, making it very unintuitive which files have failed when there are also many 0-byte files.